### PR TITLE
Update models.py

### DIFF
--- a/weblog/models.py
+++ b/weblog/models.py
@@ -120,7 +120,7 @@ class PostComment(models.Model):
         'Noun, as in blog post', 'Post'), on_delete=models.CASCADE)
     content = models.TextField(verbose_name=pgettext_lazy(
         'Of post, comment, article, etc.', 'Content'), blank=False)
-    publish_date = models.DateTimeField(verbose_name=_('Publish date'), default=timezone.now())
+    publish_date = models.DateTimeField(verbose_name=_('Publish date'), default=timezone.now)
 
     class Meta:
         verbose_name = pgettext_lazy('Noun', 'Comment')


### PR DESCRIPTION
timezone.now() should be timezone.now, at least in 2.1

> WARNINGS:
>     weblog.PostComment.publish_date: (fields.W161) Fixed default value provided.
> 	HINT: It seems you set a fixed date / time / datetime value as default for this field. This may not be what you want. If you want to have the current date as default, use `django.utils.timezone.now`